### PR TITLE
Amalgamated

### DIFF
--- a/nu/cblocks.nu
+++ b/nu/cblocks.nu
@@ -28,10 +28,7 @@
         (try ((NuBridgedBlock class)) 
             (catch (execption) (throw* "NuException" "This build of Nu does not support C blocks.")))
                 
-        (function __get_type_signature (identifier) 
-            (((NuBridgedFunction functionWithName:"signature_for_identifier" signature:"@@@") identifier 
-                (NuSymbolTable sharedSymbolTable))))
-        (set __sig (__get_type_signature (list ret)))
+        (set __sig (signature (list ret)))
         (set __blockparams ())
         (set __paramlist params)
         (until (eq __paramlist nil)
@@ -42,7 +39,7 @@
             (set __param (car (cdr __paramlist)))
             (set __paramlist (cdr (cdr __paramlist)))
             (set __sig (__sig stringByAppendingString:
-                (__get_type_signature __type)))
+                (signature __type)))
             (set __blockparams (append __blockparams (list __param))))
         ;(puts "Signature: #{__sig}")
         ;(puts "Block params: #{__blockparams}")

--- a/objc/Nu.m
+++ b/objc/Nu.m
@@ -8925,6 +8925,19 @@ static id evaluatedArguments(id cdr, NSMutableDictionary *context)
 
 @end
 
+@interface Nu_signature_operator : NuOperator {}
+@end
+
+@implementation Nu_signature_operator
+
+// signature operator; basically gives access to the static signature_for_identifier function from within Nu code
+- (id) callWithArguments:(id)cdr context:(NSMutableDictionary *)context
+{
+    return signature_for_identifier( [[cdr car] evalWithContext:context],[NuSymbolTable sharedSymbolTable]);
+}
+
+@end
+
 #define install(name, class) [(NuSymbol *) [symbolTable symbolWithString:name] setValue:[[[class alloc] init] autorelease]]
 
 void load_builtins(NuSymbolTable *symbolTable);
@@ -9056,6 +9069,8 @@ void load_builtins(NuSymbolTable *symbolTable)
     install(@"help",     Nu_help_operator);
     install(@"?",        Nu_help_operator);
     install(@"version",  Nu_version_operator);
+    
+    install(@"signature", Nu_signature_operator);
     
     // set some commonly-used globals
     [(NuSymbol *) [symbolTable symbolWithString:@"NSUTF8StringEncoding"] 

--- a/test/test_bridge.nu
+++ b/test/test_bridge.nu
@@ -39,8 +39,8 @@
 	      (num-array (array 1 2)))
 	  (set equals-num? (cblock BOOL ((id) obj (unsigned long) idx (void*) stop)
 				   (if (== obj num) YES (else NO))))
+	  (set num 1)
+	  (assert_equal 0 (num-array indexOfObjectPassingTest:equals-num?))
 	  (set num 2)
-	  (assert_equal 1 (num-array indexOfObjectPassingTest:equals-num?))
-	  (set num 3)
-	  (assert_equal NSNotFound (num-array indexOfObjectPassingTest:equals-num?)))))
+	  (assert_equal 1 (num-array indexOfObjectPassingTest:equals-num?)))))
 


### PR DESCRIPTION
Hi Tim,
  I've updated the amalgamated branch to remove the workaround that Yusef had added to get around the Snow Leopard bug that caused the method_**\* functions to misreport signatures for methods that take c blocks as parameters. Lion fixed this bug. I also added a test to test_bridge.nu for cblocks. I noticed that you made the functions in Nu.m all static. That broke Yusef's cblock macro which relied on the signature_for_identifier function, so I added a 'signature' operator to allow nu code to take advantage of that function. I think this operator could be generally useful, so I hope you let it stand. None of this has been tested on iOS. I hope these changes meet your approval :-)!
