### PR TITLE
Fix {Makefile,nuke,Nukefile} for /usr/bin/clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,11 @@ CFLAGS = -g -Wall -DMININUSH
 MFLAGS = -fobjc-exceptions
 
 ifeq ($(SYSTEM), Darwin)
-	CC = $(DEVROOT)/usr/bin/clang
+	# as of around 10.7.3, clang becomes part of OS X
+	CC = /usr/bin/clang
+	ifneq ($(shell test -e $(CC) && echo yes), yes)
+		CC = $(DEVROOT)/usr/bin/clang
+	endif
 	CFLAGS += -DMACOSX -DDARWIN $(LION_CFLAGS)  
 else
 #	CFLAGS += -DLINUX

--- a/Nukefile
+++ b/Nukefile
@@ -1,6 +1,8 @@
 ;; Nukefile for Nu framework and nush, the Nu shell
 
-(set DEVROOT "")
+(set DEVROOT
+     (ifDarwin (then (NSString stringWithShellCommand:"xcode-select -print-path"))
+               (else nil)))
  
 (global VERSION '(2 0 1)) #(major minor tweak)
 
@@ -76,8 +78,6 @@ END)
 (set @dylib "libNu")
 
 ;; build configuration
-(set @cc "gcc")
-(set @cc "#{DEVROOT}/usr/bin/clang")
 
 (set @sdkflags "")
 (set @sdk
@@ -94,10 +94,8 @@ END)
             ("-isysroot #{DEVROOT}/SDKs/MacOSX10.4u.sdk"))
            (else "")))
 
-(set @cflags "-Wall -g -fPIC")
-
 (ifDarwin
-         (then (set @cflags (+ @cflags " -g -O2 -DMACOSX #{@sdk} #{@sdkflags}"))
+         (then (set @cflags ( "-Wall -g -fPIC -O2 -DMACOSX #{@sdk} #{@sdkflags}"))
                (set @mflags_nogc "-fobjc-exceptions")
                (set @mflags (+ @mflags_nogc " -fobjc-gc"))) ;; To use garbage collection, add this flag: "-fobjc-gc"
          (else (set @cflags "-Wall -g -std=gnu99 -fPIC")

--- a/tools/nuke
+++ b/tools/nuke
@@ -283,10 +283,23 @@
      (unless momc (NSException raise:@"NukeError" format:@"Can't find momc (data model compiler)."))
      momc)
 
+(function select-compiler ()
+    (ifDarwin
+        ;; clang built-in to 10.7.3
+        (set clang "/usr/bin/clang")
+        (if (not (NSFileManager fileExistsNamed:clang))
+            ;; use xcode-select to get from e.g. /Developer or Xcode.app
+            (set DEVROOT (NSString stringWithShellCommand:"xcode-select -print-path"))
+            (set clang "#{DEVROOT}/usr/bin/clang")
+            (if (not (NSFileManager fileExistsNamed:clang))
+                (set clang nil))))
+    ;; default to gcc
+    (if (clang) clang (else "gcc")))
+
 ;; use this to create all the compilation tasks for the files in the @c_files and @m_files collections
 (macro compilation-tasks ()
      `(progn
-            (unless @cc (set @cc "gcc"))
+            (unless @cc (set @cc (select-compiler)))
             (unless @cflags (set @cflags "-g"))
             (unless @mflags (set @mflags "-fobjc-exceptions"))
             (unless @includes (set @includes ""))


### PR DESCRIPTION
- as of OSX 10.7.3 & Xcode 4.3.1
- improve logic for default @cc in nuke, so that @cc def will not 
  usually be required in a Nukefile
