### PR TITLE
testcases showing the failing expression

### DIFF
--- a/nu/nu.nu
+++ b/nu/nu.nu
@@ -116,7 +116,7 @@
                     (if (not (eval expression))
                         (then (throw ((NSException alloc)
                                       initWithName:"NuAssertionFailure"
-                                      reason:(expression stringValue)
+                                      reason:,(*body stringValue)
                                       userInfo:nil)))))))
 
 ;; Allows mapping a function over multiple lists.

--- a/nu/test.nu
+++ b/nu/test.nu
@@ -42,8 +42,11 @@
      
      ;; By overriding this method, we detect each time a class is defined in Nu that inherits from this class.
      (+ (id) inheritedByClass:(id) testClass is
-        (unless $testClasses (set $testClasses (NSMutableSet set)))
-        ($testClasses addObject:testClass))
+	 (unless $testClasses (set $testClasses (NSMutableSet set)))
+	 ;; we need to check for the existence of testClass because reloading
+	 ;; a file with a class definition will call this again but with nil
+	 (if (testClass)
+	      $testClasses addObject:testClass))
      
      ;; The setup method is called before each test case is executed.
      ;; The default implementation does nothing.


### PR DESCRIPTION
Added an check so testcases can be loaded again on runtime, allowing a kind of infile tests.
Changed testcase output on error to show the failing expression.
