### PR TITLE
Add "map" to NSDictionary

### DIFF
--- a/objc/Nu.m
+++ b/objc/Nu.m
@@ -4378,6 +4378,24 @@ static NSComparisonResult sortedArrayUsingBlockHelper(id a, id b, void *context)
     return self;
 }
 
+- (NSDictionary *) map: (id) callable
+{
+    NSMutableDictionary *results = [NSMutableDictionary dictionary];
+    id args = [[NuCell alloc] init];
+    if ([callable respondsToSelector:@selector(evalWithArguments:context:)]) {
+        NSEnumerator *enumerator = [self keyEnumerator];
+        id object;
+        while ((object = [enumerator nextObject])) {
+            [args setCar:object];
+            [args setCdr:[[[NuCell alloc] init] autorelease]];
+            [[args cdr] setCar:[self objectForKey:object]];
+            [results setObject:[callable evalWithArguments:args context:nil] forKey:object];
+        }
+    }
+    [args release];
+    return results;
+}
+
 @end
 
 @implementation NSMutableDictionary(Nu)

--- a/test/test_dictionary.nu
+++ b/test/test_dictionary.nu
@@ -50,6 +50,14 @@
                (if (eq v 3) (continue))
                (set count (+ count 1))))
         (assert_equal (- (d count) 1) count))
+      
+      (- (id) testMap is
+        (set d (dict one:1 two:2 three:3 four:4))
+        (set o (d map:(do (k v) (+ 1 v))))
+        (assert_equal (d count) (o count))
+        (d each:
+           (do (k v)
+               (assert_equal (+ 1 v) (o k)))))
      
      (- (id) testLookupWithDefault is
         (set d (dict "one" 1 two:2))


### PR DESCRIPTION
If you send the map: message to a dictionary and it will apply the provided
callable to each value and return another dictionary with the results set for
the corresponding keys.

E.g.:

```
% (set origin (dict "alpha" 10 "bravo" 20))
<__NSDictionaryM:7f9224202c50>
% (set destination (origin map: (do (x y) (+ 1 y))))
<__NSDictionaryM:7f9224202f40>
% (destination "bravo")
21
```
