### PR TITLE
Remove duplicate method declaration

### DIFF
--- a/objc/Nu.h
+++ b/objc/Nu.h
@@ -708,7 +708,6 @@
 
 /*! Get the stack trace. */
 - (NSArray*)stackTrace;
-- (NSString*)dump;
 
 /*! Add to the stack trace. */
 - (NuException *)addFunction:(NSString *)function lineNumber:(int)line;


### PR DESCRIPTION
This causes a warning in Xcode with current recommended settings.
