### PR TITLE
Remove compiling with objc gc

### DIFF
--- a/Nukefile
+++ b/Nukefile
@@ -99,8 +99,7 @@ END)
 
 (ifDarwin
          (then (set @cflags ( "-Wall -g -fPIC -O2 -DMACOSX #{@sdk} #{@sdkflags}"))
-               (set @mflags_nogc "-fobjc-exceptions")
-               (set @mflags (+ @mflags_nogc " -fobjc-gc"))) ;; To use garbage collection, add this flag: "-fobjc-gc"
+               (set @mflags "-fobjc-exceptions"))
          (else (set @cflags "-Wall -g -std=gnu99 -fPIC")
                (set @mflags ((NSString stringWithShellCommand:"gnustep-config --objc-flags") chomp))))
 
@@ -131,7 +130,7 @@ END)
                           (then
                             ((@lib_dirs map:
                                  (do (libdir) " -L#{libdir} ")) join))
-                          (else 
+                          (else
                             ((@lib_dirs map:
                                  (do (libdir) " -L#{libdir} -Wl,--rpath #{libdir}")) join))))))
      join))
@@ -167,7 +166,7 @@ END)
            (ifDarwin
                     (then
                          (file nush_thin_binary => "framework" "build/#{architecture}/main.o" is
-                               (SH "#{@cc} #{@cflags} #{@mflags_nogc} main/main.m -arch #{architecture} -F. -framework Nu #{@ldflags} -o #{(target name)}")))
+                               (SH "#{@cc} #{@cflags} #{@mflags} main/main.m -arch #{architecture} -F. -framework Nu #{@ldflags} -o #{(target name)}")))
                     (else
                          (file nush_thin_binary => "dylib" (@c_objects objectForKey:architecture) (@m_objects objectForKey:architecture) is
                                (SH "#{@cc} #{@cflags} #{@mflags} main/main.m #{@library_executable_name} #{@ldflags} #{@gnustep_flags} -o #{(target name)}"))))))


### PR DESCRIPTION
I'm not sure of the full implications of this, but I had to remove gc to compile nu. I'm running OS X 10.9.2 with xcode 5.1 and command line tools 5.1.0.0.1.1393561416.

Here's the error:

``` sh
$ ./mininush tools/nuke
Using Nukefile with target default.
nuke: running in /Users/sj26/Projects/nu
nuke: /usr/bin/clang -Wall -g -fPIC -O2 -DMACOSX   -DHAVE_CONFIG_H -fobjc-exceptions -fobjc-gc -arch x86_64  -I/usr/include  -I./include  -I./include/Nu  -I/usr/local/include  -I/usr/include/ffi -c -o build/x86_64/Nu.o objc/Nu.m
error: garbage collection is no longer supported
nuke: terminating on command error (return code 1)
```
