### PR TITLE
Add missing readline/history.h include in NuParser

### DIFF
--- a/objc/NuParser.m
+++ b/objc/NuParser.m
@@ -16,6 +16,7 @@
 #import "NuCell.h"
 #if !TARGET_OS_IPHONE
 #include <readline/readline.h>
+#include <readline/history.h>
 #endif
 
 #define PARSE_NORMAL     0


### PR DESCRIPTION
When building on Ubuntu, we encounter the following errors:

```
objc/NuParser.m:1009:13: error: call to undeclared function 'read_history'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            read_history(history_file);
            ^
objc/NuParser.m:1030:13: error: call to undeclared function 'add_history'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            add_history (line);
            ^
objc/NuParser.m:1092:9: error: call to undeclared function 'write_history'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        write_history(history_file);
        ^
3 errors generated.
make: *** [Makefile:109: objc/NuParser.o] Error 1
make: *** Waiting for unfinished jobs....
```

As shown in [this example](https://web.mit.edu/gnu/doc/html/rlman_2.html#SEC40), `<readline/history.h>` contains `read_history`, `add_history`, and `write_history`.